### PR TITLE
stop rendering views in specs

### DIFF
--- a/spec/controllers/games_controller_spec.rb
+++ b/spec/controllers/games_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe GamesController, type: :controller do
-  render_views
 
   before do
     @user = create(:user)


### PR DESCRIPTION
It is no longer necessary to render views because rails-controller-testing serves that purpose without actually rendering views.