### PR TITLE
Add support for card images

### DIFF
--- a/app/helpers/games_helper.rb
+++ b/app/helpers/games_helper.rb
@@ -1,7 +1,7 @@
 module GamesHelper
   def present_guess(card)
     if card.matched? || card.revealed?
-      return card.content
+      return image_tag(card.image_url)
     else    
       return image_tag('pokeball.png')
     end
@@ -9,7 +9,7 @@ module GamesHelper
 
   def present_card(card)
     if card.matched?
-      return card.content
+      return image_tag(card.image_url)
     else    
       return image_tag('pokeball.png')
     end

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -1,16 +1,18 @@
 class Card < ApplicationRecord
   belongs_to :game
 
-  CARD_CONTENT = [
-    'Pikachu',
-    'Bulbasaur',
-    'Charmander',
-    'Squirtle',
-    'Eevee',
-    'Chikorita',
-    'Cyndaquil',
-    'Totodile',
-    'Marill'
+  Card = Struct.new(:content, :image_url)
+
+  CARDS = [
+    Card.new('Pikachu', 'pikachu.png'),
+    Card.new('Bulbasaur', 'bulbasaur.png'),
+    Card.new('Charmander', 'charmander.png'),
+    Card.new('Squirtle', 'squirtle.png'),
+    Card.new('Eevee', 'eevee.png'),
+    Card.new('Chikorita', 'chikorita.png'),
+    Card.new('Cyndaquil', 'cyndaquil.png'),
+    Card.new('Totodile', 'totodile.png'),
+    Card.new('Marill' 'marrill.png')
   ]
 
   def matched?

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -25,8 +25,8 @@ class Game < ApplicationRecord
   end
 
   def generate_cards
-    (Card::CARD_CONTENT*2).shuffle.each_with_index do |content, index|
-      self.cards.create(content: content, position: index)
+    (Card::CARDS*2).shuffle.each_with_index do |card, index|
+      self.cards.create(content: card.content, image_url: card.image_url, position: index)
     end
   end
 end

--- a/db/migrate/20161231021251_add_image_url_to_cards.rb
+++ b/db/migrate/20161231021251_add_image_url_to_cards.rb
@@ -1,0 +1,5 @@
+class AddImageUrlToCards < ActiveRecord::Migration[5.0]
+  def change
+    add_column :cards, :image_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161230001535) do
+ActiveRecord::Schema.define(version: 20161231021251) do
 
   create_table "cards", force: :cascade do |t|
     t.integer  "game_id"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 20161230001535) do
     t.boolean  "matched",    default: false
     t.datetime "created_at",                 null: false
     t.datetime "updated_at",                 null: false
+    t.string   "image_url"
   end
 
   create_table "games", force: :cascade do |t|


### PR DESCRIPTION
This PR adds a new attribute to the `Card` object to hold an image, which serves as the front of a card. It also changes the way cards are generated by adding a Struct and iterating through attributes of the struct rather than an array of strings.